### PR TITLE
.gitignore: Ignore /venv/ virtual environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
+venv/
 env/
 build/
 develop-eggs/


### PR DESCRIPTION
The template had env, but not venv, which is pretty weird but ok