### PR TITLE
cli: Add `load' subcommand for loading submissions

### DIFF
--- a/zucchini/cli.py
+++ b/zucchini/cli.py
@@ -116,6 +116,25 @@ def init(state, assignment_name, target):
                                                          target))
 
 
+@cli.group()
+@pass_state
+def load(state):
+    """Load student submissions."""
+    pass
+
+
+@load.command('sakai')
+def load_sakai(state):
+    """Load student submissions from Sakai"""
+    pass
+
+
+@load.command('canvas')
+def load_canvas(state):
+    """Load student submissions from Canvas"""
+    pass
+
+
 @cli.command()
 @click.option('-f', '--from-dir', default=DEFAULT_SUBMISSION_DIRECTORY,
               help="Path of the directory to read submissions from.",


### PR DESCRIPTION
This is small but worth discussing, since Canvas once again makes a hardcoded appearance here. It would be nice if these "modules" could configure click as well as configuration