### PR TITLE
LibcheckGrader: list_prerequisites() belongs in LibcheckGrader

### DIFF
--- a/zucchini/graders/libcheck_grader.py
+++ b/zucchini/graders/libcheck_grader.py
@@ -24,9 +24,6 @@ class LibcheckTest(Part):
     def __init__(self, name):
         self.name = name
 
-    def list_prerequisites(self):
-        return ['sudo apt-get install build-essential check valgrind']
-
     def description(self):
         return self.name
 
@@ -126,6 +123,9 @@ class LibcheckGrader(ThreadedGrader):
             self.timeout = self.DEFAULT_TIMEOUT
         else:
             self.timeout = timeout
+
+    def list_prerequisites(self):
+        return ['sudo apt-get install build-essential check valgrind']
 
     def grade_part(self, part, path, submission):
         return part.grade(path, self)


### PR DESCRIPTION
I accidentally wrote list_prerequisites() in LibcheckTest instead of
LibcheckGrader.