### PR TITLE
Don't parse assignment_id from gradescope metadata

### DIFF
--- a/zucchini/gradescope.py
+++ b/zucchini/gradescope.py
@@ -21,7 +21,6 @@ class GradescopeMetadata(object):
 
     _ATTRS = {
         'created_at': datetime_from_string,
-        'assignment_id': int,
     }
 
     def __init__(self, json_dict):


### PR DESCRIPTION
We don't need this and apparently it's null sometimes.