### PR TITLE
Display verbose errors on Gradescope

### DIFF
--- a/zucchini/graders/bitwise_json_grader.py
+++ b/zucchini/graders/bitwise_json_grader.py
@@ -94,7 +94,8 @@ class BitwiseJSONGrader(GraderInterface):
 
         if process.returncode != 0:
             raise BrokenSubmissionError(
-                'grader command exited with nonzero exit code {}'
+                ('grader command exited with nonzero exit code {}. '
+                 'syntax error?')
                 .format(process.returncode),
                 verbose=process.stdout.decode() if process.stdout else None)
 

--- a/zucchini/grades.py
+++ b/zucchini/grades.py
@@ -60,11 +60,13 @@ class AssignmentComponentGrade(ConfigDictMixin):
                                          points_possible=Fraction(0),
                                          grade=Fraction(1),
                                          error=None,
+                                         error_verbose=None,
                                          parts=[])
 
         if self.is_broken():
             grade.points_got = Fraction(0)
             grade.error = self.error
+            grade.error_verbose = self.error_verbose
         else:
             for part, part_grade in zip(component_parts, self.part_grades):
                 calc_part_grade = part.calculate_grade(
@@ -146,7 +148,7 @@ class CalculatedComponentGrade(Record):
     possible.
     """
     __slots__ = ['name', 'points_delta', 'points_got', 'points_possible',
-                 'grade', 'error', 'parts']
+                 'grade', 'error', 'error_verbose', 'parts']
 
 
 class CalculatedPartGrade(Record):

--- a/zucchini/gradescope.py
+++ b/zucchini/gradescope.py
@@ -102,7 +102,8 @@ class GradescopeAutograderOutput(ConfigDictNoMangleMixin, ConfigDictMixin):
                     name=component.name,
                     score=cls._two_decimals(component.points_got),
                     max_score=cls._two_decimals(component.points_possible),
-                    output=component.error)
+                    output='{}\n{}'.format(component.error,
+                                           component.error_verbose or ''))
                 tests.append(test)
             else:
                 for part in component.parts:

--- a/zucchini/grading_manager.py
+++ b/zucchini/grading_manager.py
@@ -268,9 +268,12 @@ class Grade(object):
             for component in grade.components:
                 if component.error is not None:
                     assignment_pass = False
-                    f.write("(%s / %s) [FAIL] TOTAL for %s: %s\n\n" % (
-                        component.points_got, component.points_possible,
-                        component.name, component.error))
+                    f.write("(%s / %s) [FAIL] TOTAL for %s: %s%s\n\n" % (
+                        self._left_pad(component.points_got),
+                        self._left_pad(component.points_possible),
+                        component.name, component.error,
+                        ('\n' + component.error_verbose)
+                        if component.error_verbose else ''))
                 else:
                     component_pass = True
 


### PR DESCRIPTION
We have a nice (or at least nicer) error message in the metadata but never pass that out, not even to gradelogs. So fix that.

Not sure how this slipped through, rip in pizza.