### PR TITLE
Use Gradescope autograder component weight as total_points

### DIFF
--- a/zucchini/cli.py
+++ b/zucchini/cli.py
@@ -961,8 +961,8 @@ def gradescope_bridge(state, metadata_path):
     metadata = GradescopeMetadata.from_json_path(metadata_path)
     assignment = state.get_assignment()
 
-    seconds_late = \
-        max(int((metadata.submission_date - metadata.due_date).total_seconds()), 0)
+    late_deltatime = metadata.submission_date - metadata.due_date
+    seconds_late = max(int(late_deltatime.total_seconds()), 0)
 
     submission = Submission.load_from_component_grades_json(
         assignment, seconds_late=seconds_late, component_grades_fp=sys.stdin)

--- a/zucchini/cli.py
+++ b/zucchini/cli.py
@@ -962,7 +962,7 @@ def gradescope_bridge(state, metadata_path):
     assignment = state.get_assignment()
 
     seconds_late = \
-        max(int((metadata.created_at - metadata.due_date).total_seconds()), 0)
+        max(int((metadata.submission_date - metadata.due_date).total_seconds()), 0)
 
     submission = Submission.load_from_component_grades_json(
         assignment, seconds_late=seconds_late, component_grades_fp=sys.stdin)

--- a/zucchini/gradescope.py
+++ b/zucchini/gradescope.py
@@ -24,7 +24,8 @@ class GradescopeMetadata(object):
         ('due_date', 'assignment.due_date', datetime_from_string),
         # The nested int(float(..)) deal is because int('100.0')
         # explodes
-        ('total_points', 'assignment.outline.0.weight', lambda pts: int(float(pts))),
+        ('total_points', 'assignment.outline.0.weight',
+            lambda pts: int(float(pts))),
     ]
 
     def __init__(self, json_dict):

--- a/zucchini/gradescope.py
+++ b/zucchini/gradescope.py
@@ -10,7 +10,7 @@ from zipfile import ZipFile, ZIP_DEFLATED
 from . import __version__ as ZUCCHINI_VERSION
 from .constants import ASSIGNMENT_CONFIG_FILE, ASSIGNMENT_FILES_DIRECTORY
 from .utils import ConfigDictMixin, ConfigDictNoMangleMixin, \
-                   datetime_from_string
+                   datetime_from_string, recursive_get_using_string
 
 
 class GradescopeMetadata(object):
@@ -19,22 +19,17 @@ class GradescopeMetadata(object):
     https://gradescope-autograders.readthedocs.io/en/latest/submission_metadata/
     """
 
-    _ATTRS = {
-        'created_at': datetime_from_string,
-        'assignment.due_date': datetime_from_string,
+    _ATTRS = [
+        ('submission_date', 'created_at', datetime_from_string),
+        ('due_date', 'assignment.due_date', datetime_from_string),
         # The nested int(float(..)) deal is because int('100.0')
         # explodes
-        'assignment.total_points': lambda pts: int(float(pts)),
-    }
+        ('total_points', 'assignment.outline.0.weight', lambda pts: int(float(pts))),
+    ]
 
     def __init__(self, json_dict):
-        for attr, type_ in self._ATTRS.items():
-            if '.' in attr:
-                left, right = attr.split('.')
-                val = json_dict[left][right]
-                attr = right
-            else:
-                val = json_dict[attr]
+        for attr, key, type_ in self._ATTRS:
+            val = recursive_get_using_string(json_dict, key)
             setattr(self, attr, type_(val))
 
     @classmethod

--- a/zucchini/utils.py
+++ b/zucchini/utils.py
@@ -40,6 +40,7 @@ def mkdir_p(path):
         else:
             raise
 
+
 def recursive_get_using_string(collection, key):
     """
     Given a collection and a key in the format of x.y.z.a, return collection

--- a/zucchini/utils.py
+++ b/zucchini/utils.py
@@ -40,6 +40,23 @@ def mkdir_p(path):
         else:
             raise
 
+def recursive_get_using_string(collection, key):
+    """
+    Given a collection and a key in the format of x.y.z.a, return collection
+    [x][y][z][a].
+    """
+
+    if "." not in key:
+        if key.isdigit():
+            key = int(key)
+
+        return collection[key]
+
+    left, right = key.split('.', 1)
+    return recursive_get_using_string(
+            recursive_get_using_string(collection, left),
+            right)
+
 
 def run_thread(func, args, result_queue):
     """


### PR DESCRIPTION
So far zucchini had been using the total_points field in the Gradescope metadata as the maximum possible points on the assignment, which was a problem when the assignment also had manual grading components on Gradescope. They've now added a field that tells us exactly how many points belong to the autograder - this PR modifies zucchini to use that field.