### PR TITLE
Make libcheck backend require pkg-config

### DIFF
--- a/zucchini/graders/libcheck_grader.py
+++ b/zucchini/graders/libcheck_grader.py
@@ -125,7 +125,7 @@ class LibcheckGrader(ThreadedGrader):
             self.timeout = timeout
 
     def list_prerequisites(self):
-        return ['build-essential', 'check', 'valgrind']
+        return ['build-essential', 'check', 'valgrind', 'pkg-config']
 
     def grade_part(self, part, path, submission):
         return part.grade(path, self)


### PR DESCRIPTION
We need to add a flag that takes additional packages for backends in
general but it's 1:30am and I don't even care dude