### PR TITLE
Libcheck backend: Use less aggressive timeouts

### DIFF
--- a/zucchini/graders/libcheck_grader.py
+++ b/zucchini/graders/libcheck_grader.py
@@ -127,7 +127,7 @@ class LibcheckGrader(ThreadedGrader):
 
         self.build_timeout = self.DEFAULT_BUILD_TIMEOUT \
             if build_timeout is None else build_timeout
-        self.test_timeout = self.DEFAULT_TIMEOUT \
+        self.test_timeout = self.DEFAULT_TEST_TIMEOUT \
             if test_timeout is None else test_timeout
         self.valgrind_timeout = self.DEFAULT_VALGRIND_TIMEOUT \
             if valgrind_timeout is None else valgrind_timeout

--- a/zucchini/graders/libcheck_grader.py
+++ b/zucchini/graders/libcheck_grader.py
@@ -33,7 +33,7 @@ class LibcheckTest(Part):
 
     @staticmethod
     def test_error_grade(message):
-        return PartGrade(Fraction(0), deductions=('error'), log=message)
+        return PartGrade(Fraction(0), deductions=('error',), log=message)
 
     def grade(self, path, grader):
         """Grade a single libcheck test"""
@@ -53,8 +53,11 @@ class LibcheckTest(Part):
                               cwd=path, stdout=PIPE, stderr=STDOUT)
 
         if process.returncode != 0:
-            return self.test_error_grade('tester exited with {} != 0'
-                                         .format(process.returncode))
+            return self.test_error_grade('tester exited with {} != 0:\n{}'
+                                         .format(process.returncode,
+                                                 process.stdout.decode()
+                                                 if process.stdout is not None
+                                                 else '(no output)'))
         try:
             with open(logfile_path, 'r') as logfile:
                 logfile_contents = logfile.read()


### PR DESCRIPTION
Don't want our friend valgrind to timeout so quickly