### PR TITLE
Add partial credit toggle for components

### DIFF
--- a/zucchini/assignment.py
+++ b/zucchini/assignment.py
@@ -28,9 +28,10 @@ class ComponentPart(namedtuple('ComponentPart',
 class AssignmentComponent(ConfigDictMixin):
     def __init__(self, assignment, name, backend, weight, parts, files=None,
                  optional_files=None, grading_files=None,
-                 backend_options=None):
+                 backend_options=None, partial_credit=True):
         self.assignment = assignment
         self.name = name
+        self.partial_credit = bool(partial_credit)
 
         # Get the backend class
         if backend not in AVAILABLE_GRADERS:
@@ -151,7 +152,7 @@ class AssignmentComponent(ConfigDictMixin):
         points = Fraction(self.weight, total_weight)
         return component_grade.calculate_grade(points, self.name,
                                                self.total_part_weight,
-                                               self.parts)
+                                               self.parts, self.partial_credit)
 
 
 class AssignmentPenalty(ConfigDictMixin):

--- a/zucchini/assignment.py
+++ b/zucchini/assignment.py
@@ -18,11 +18,13 @@ from .utils import ConfigDictMixin, copy_globs, sanitize_path
 
 class ComponentPart(namedtuple('ComponentPart',
                                ['weight', 'part', 'partial_credit'])):
-    def calculate_grade(self, component_points, total_part_weight, part_grade):
+    def calculate_grade(self, component_points, total_part_weight, part_grade,
+                        force_zero=False):
         points = component_points * Fraction(self.weight, total_part_weight)
         return part_grade.calculate_grade(points,
                                           self.part,
-                                          self.partial_credit)
+                                          self.partial_credit,
+                                          force_zero)
 
 
 class AssignmentComponent(ConfigDictMixin):

--- a/zucchini/grades.py
+++ b/zucchini/grades.py
@@ -132,11 +132,8 @@ class PartGrade(ConfigDictMixin):
 
         log = self.log
         if force_zero:
-            log = "%s\n\n%s" % (
-                "You need to pass all parts of this component to get credit.",
-                log
-            )
-
+            log = "You need to pass all parts of {{componentName}} to get" \
+                  "credit.\n\n{log}".format(log=log)
         grade = Fraction(points_got, points)
 
         return CalculatedPartGrade(name=part.description(),

--- a/zucchini/grades.py
+++ b/zucchini/grades.py
@@ -45,7 +45,7 @@ class AssignmentComponentGrade(ConfigDictMixin):
         return self.error is not None
 
     def calculate_grade(self, points, name, total_part_weight,
-                        component_parts):
+                        component_parts, partial_credit):
         # type: (List[ComponentPart]) -> CalculatedComponentGrade
         """
         Using the list of ComponentPart instances provided (which
@@ -74,7 +74,16 @@ class AssignmentComponentGrade(ConfigDictMixin):
                 grade.parts.append(calc_part_grade)
                 grade.points_got += calc_part_grade.points_got
 
+            # Make a second pass through the grades if partial credit is not allowed
+            if not partial_credit and (grade.points_got < points):
+                grade.points_got = Fraction(0)
+                for part, part_grade in zip(component_parts, self.part_grades):
+                    calc_part_grade = part.calculate_grade(
+                        points, total_part_weight, part_grade, force_zero=True)
+                    grade.parts.append(calc_part_grade)
+
         grade.points_possible = points
+
         grade.points_delta = grade.points_got - grade.points_possible
         grade.grade = Fraction(grade.points_got, grade.points_possible)
 
@@ -114,18 +123,24 @@ class PartGrade(ConfigDictMixin):
         part_grade.score = Fraction(part_grade.score)
         return part_grade
 
-    def calculate_grade(self, points, part, partial_credit):
+    def calculate_grade(self, points, part, partial_credit, force_zero=False):
         points_got = self.score * points
-        if not partial_credit and points_got < points:
+        if force_zero or (not partial_credit and points_got < points):
             points_got = Fraction(0)
+
+        log = self.log
+        if force_zero:
+            log = "You need to pass all parts of this component to get credit.\n\n" + log
+
+        grade = Fraction(points_got, points)
 
         return CalculatedPartGrade(name=part.description(),
                                    points_delta=points_got - points,
                                    points_got=points_got,
                                    points_possible=points,
-                                   grade=self.score,
+                                   grade=grade,
                                    deductions=self.deductions,
-                                   log=self.log)
+                                   log=log)
 
 
 class CalculatedGrade(Record):

--- a/zucchini/grades.py
+++ b/zucchini/grades.py
@@ -84,6 +84,11 @@ class AssignmentComponentGrade(ConfigDictMixin):
                         points, total_part_weight, part_grade, force_zero=True)
                     grade.parts.append(calc_part_grade)
 
+            # Insert name in the logs if required by the log in any of the parts
+            for calc_part_grade in grade.parts:
+                log = calc_part_grade.log.format(componentName=name)
+                calc_part_grade.log = log
+
         grade.points_possible = points
 
         grade.points_delta = grade.points_got - grade.points_possible
@@ -133,7 +138,7 @@ class PartGrade(ConfigDictMixin):
         log = self.log
         if force_zero:
             log = "You need to pass all parts of {{componentName}} to get" \
-                  "credit.\n\n{log}".format(log=log)
+                  " credit.\n\n{log}".format(log=log)
         grade = Fraction(points_got, points)
 
         return CalculatedPartGrade(name=part.description(),

--- a/zucchini/grades.py
+++ b/zucchini/grades.py
@@ -74,9 +74,11 @@ class AssignmentComponentGrade(ConfigDictMixin):
                 grade.parts.append(calc_part_grade)
                 grade.points_got += calc_part_grade.points_got
 
-            # Make a second pass through the grades if partial credit is not allowed
+            # Make a second pass if partial credit is not allowed
             if not partial_credit and (grade.points_got < points):
                 grade.points_got = Fraction(0)
+                grade.parts = []
+
                 for part, part_grade in zip(component_parts, self.part_grades):
                     calc_part_grade = part.calculate_grade(
                         points, total_part_weight, part_grade, force_zero=True)
@@ -130,7 +132,10 @@ class PartGrade(ConfigDictMixin):
 
         log = self.log
         if force_zero:
-            log = "You need to pass all parts of this component to get credit.\n\n" + log
+            log = "%s\n\n%s" % (
+                "You need to pass all parts of this component to get credit.",
+                log
+            )
 
         grade = Fraction(points_got, points)
 


### PR DESCRIPTION
This adds a partial credit toggle for components and converts calculated part grades to zeroes if the component does not allow partial credit and full credit has not been received. Compatible with gradescope and with `zucc grade`.