### PR TITLE
A little extra defense.

### DIFF
--- a/zucchini/graders/pylc3_grader.py
+++ b/zucchini/graders/pylc3_grader.py
@@ -24,7 +24,7 @@ class PyLC3Test(Part):
     def grade(self, result):
         if result is None:
             return PartGrade(score=Fraction(0),
-                             log='results for test not found. misspelling?')
+                             log='results for test not found. misspelling? If you received this message and you are a student ensure your assembly files assemble by loading into complx and that you did not change any of the default labels.')
 
         log = '\n'.join('{0[display-name]}: {0[message]}'.format(test)
                         for test in result if not test['passed'])


### PR DESCRIPTION
Should already be fixed on the pyLC3 side, but just in case in the future some catastrophic error message happens and doesn't make it into the json file add an additional message to students to check the assembly file for any mistakes.