### PR TITLE
Gradescope: Report 0% grade on zero-point part as a failure

### DIFF
--- a/zucchini/graders/__init__.py
+++ b/zucchini/graders/__init__.py
@@ -16,9 +16,9 @@ from .lc3tools_grader import LC3ToolsGrader
 
 __all__ = ['InvalidGraderConfigError', 'GraderInterface', 'Part',
            'ThreadedGrader', 'PromptGrader', 'OpenFileGrader', 'CommandGrader',
-           'LC3ToolsGrader', 'LibcheckGrader', 'JUnitJSONGrader', 'JUnitXMLGrader',
-           'BitwiseJSONGrader', 'CircuitSimGrader', 'PyLC3Grader',
-           'MultiCommandGrader', 'PythonModuleGrader']
+           'LC3ToolsGrader', 'LibcheckGrader', 'JUnitJSONGrader',
+           'JUnitXMLGrader', 'BitwiseJSONGrader', 'CircuitSimGrader',
+           'PyLC3Grader', 'MultiCommandGrader', 'PythonModuleGrader']
 
 _GRADERS = (
     PromptGrader,

--- a/zucchini/graders/lc3tools_grader.py
+++ b/zucchini/graders/lc3tools_grader.py
@@ -1,7 +1,6 @@
 import re
 from fractions import Fraction
 
-from ..submission import BrokenSubmissionError
 from ..utils import run_process, PIPE, STDOUT
 from ..grades import PartGrade
 from . import ThreadedGrader, Part
@@ -15,11 +14,11 @@ class LC3ToolsTest(Part):
 
     def description(self):
         return self.name
-    
+
     @staticmethod
     def format_cmd(cmd, **kwargs):
         return [arg.format(**kwargs) for arg in cmd]
-    
+
     @staticmethod
     def test_error_grade(message):
         return PartGrade(Fraction(0), deductions=('error',), log=message)
@@ -28,7 +27,7 @@ class LC3ToolsTest(Part):
         grade = PartGrade(Fraction(1), log='')
 
         run_cmd = self.format_cmd(grader.cmdline, testcase=self.name)
-        
+
         process = run_process(run_cmd, cwd=path, stdout=PIPE, stderr=STDOUT)
 
         if process.returncode != 0:
@@ -37,13 +36,13 @@ class LC3ToolsTest(Part):
                                                  process.stdout.decode()
                                                  if process.stdout is not None
                                                  else '(no output)'))
-        
+
         out_contents = process.stdout.decode()
         out_contents = re.sub(r'\(\+.*pts\)', '', out_contents)
         results = "".join(out_contents.strip().splitlines(keepends=True)[:-1])
         grade.log += results
 
-        try:    
+        try:
             summary = out_contents.splitlines()[-1]
             score = summary.replace("/", " ").split()[3:5]
             score[0] = Fraction(float(score[0]))
@@ -70,8 +69,9 @@ class LC3ToolsGrader(ThreadedGrader):
         self.test_file = test_file
         self.asm_file = asm_file
 
-        self.cmdline = ["./" + self.test_file, self.asm_file, '--test-filter={testcase}',
-                        "--tester-verbose", "--asm-print-level=3" ]
+        self.cmdline = ["./" + self.test_file, self.asm_file,
+                        '--test-filter={testcase}', "--tester-verbose",
+                        "--asm-print-level=3"]
 
         self.timeout = self.DEFAULT_TIMEOUT \
             if timeout is None else timeout
@@ -81,7 +81,7 @@ class LC3ToolsGrader(ThreadedGrader):
 
     def part_from_config_dict(self, config_dict):
         return LC3ToolsTest.from_config_dict(config_dict)
-    
+
     def grade_part(self, part, path, submission):
         return part.grade(path, self)
 

--- a/zucchini/grades.py
+++ b/zucchini/grades.py
@@ -62,6 +62,8 @@ class AssignmentComponentGrade(ConfigDictMixin):
                                          error_verbose=None,
                                          parts=[])
 
+        grade.grade = Fraction(0)
+
         if self.is_broken():
             grade.points_got = Fraction(0)
             grade.error = self.error
@@ -72,10 +74,11 @@ class AssignmentComponentGrade(ConfigDictMixin):
                     points, total_part_weight, part_grade)
                 grade.parts.append(calc_part_grade)
                 grade.points_got += calc_part_grade.points_got
+                grade.grade += part_grade.score * Fraction(part.weight,
+                                                           total_part_weight)
 
         grade.points_possible = points
         grade.points_delta = grade.points_got - grade.points_possible
-        grade.grade = Fraction(grade.points_got, grade.points_possible)
 
         return grade
 

--- a/zucchini/utils.py
+++ b/zucchini/utils.py
@@ -234,7 +234,7 @@ class ConfigDictMixin(object):
         Exclude arguments found in `exclude_args'.
         """
 
-        arg_spec = inspect.getargspec(cls.__init__)
+        arg_spec = inspect.getfullargspec(cls.__init__)
         num_optional_args = 0 if arg_spec.defaults is None \
             else min(len(arg_spec.args)-1, len(arg_spec.defaults))
         first_optional_arg = len(arg_spec.args) - num_optional_args


### PR DESCRIPTION
This way, we can add tests that don't impact the student's grade but should still get their attention.

### Testing

Added a zero-weighted part to the Project 4 autograder and verified that failing it sets the [`status` of the corresponding Gradescope test case to `"failed"`][1], and that passing it yields `"passed"`. Did not run through Gradescope to make sure it interprets that JSON as we expect since I don't understand all this newfangled Docker stuff

[1]: https://gradescope-autograders.readthedocs.io/en/latest/specs/#test-case-status