### PR TITLE
Show human-readable signal description in libcheck tests

### DIFF
--- a/zucchini/graders/libcheck_grader.py
+++ b/zucchini/graders/libcheck_grader.py
@@ -3,6 +3,7 @@ import re
 import shlex
 import tempfile
 from fractions import Fraction
+from signal import strsignal
 
 from ..submission import BrokenSubmissionError
 from ..utils import run_process, PIPE, STDOUT, TimeoutExpired
@@ -55,6 +56,8 @@ class LibcheckTest(Part):
                                    str(grader.test_timeout)},
                               cwd=path, stdout=PIPE, stderr=STDOUT)
 
+        if process.returncode < 0:
+            return self.test_error_grade(strsignal(-process.returncode))
         if process.returncode != 0:
             return self.test_error_grade('tester exited with {} != 0:\n{}'
                                          .format(process.returncode,


### PR DESCRIPTION
Right now if a libcheck-graded program segfaults, zucchini just says "tester exited with -11 != 0." This should add a special case for programs that terminated with a signal and prints out the human-readable name of the signal. It uses `signal.strsignal`, which is Python 3.8+ only.