### PR TITLE
Modify lc3tools grader to leverage new testing framework

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 2.1.11
+current_version = 2.2.0
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ test_requirements = [
 
 setup(
     name='zucchini',
-    version='2.1.11',
+    version='2.2.0',
     description="Zucchini is an automatic grader tool for use in grading programming assignments.",
     long_description=readme + '\n\n' + history,
     author="Zucchini Team",

--- a/zucchini/__init__.py
+++ b/zucchini/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Zucchini Team"""
 __email__ = 'team@zucc.io'
-__version__ = '2.1.11'
+__version__ = '2.2.0'

--- a/zucchini/graders/__init__.py
+++ b/zucchini/graders/__init__.py
@@ -13,18 +13,21 @@ from .pylc3_grader import PyLC3Grader
 from .multi_command_grader import MultiCommandGrader
 from .python_module_grader import PythonModuleGrader
 from .lc3tools_grader import LC3ToolsGrader
+from .lc3tools_legacy_grader import LC3ToolsLegacyGrader
 
 __all__ = ['InvalidGraderConfigError', 'GraderInterface', 'Part',
            'ThreadedGrader', 'PromptGrader', 'OpenFileGrader', 'CommandGrader',
-           'LC3ToolsGrader', 'LibcheckGrader', 'JUnitJSONGrader',
-           'JUnitXMLGrader', 'BitwiseJSONGrader', 'CircuitSimGrader',
-           'PyLC3Grader', 'MultiCommandGrader', 'PythonModuleGrader']
+           'LC3ToolsGrader', 'LC3ToolsLegacyGrader', 'LibcheckGrader',
+           'JUnitJSONGrader', 'JUnitXMLGrader', 'BitwiseJSONGrader',
+           'CircuitSimGrader', 'PyLC3Grader', 'MultiCommandGrader',
+           'PythonModuleGrader']
 
 _GRADERS = (
     PromptGrader,
     OpenFileGrader,
     CommandGrader,
     LC3ToolsGrader,
+    LC3ToolsLegacyGrader,
     LibcheckGrader,
     JUnitJSONGrader,
     JUnitXMLGrader,

--- a/zucchini/graders/lc3tools_grader.py
+++ b/zucchini/graders/lc3tools_grader.py
@@ -71,7 +71,13 @@ class LC3ToolsGrader(GraderInterface):
         return LC3ToolsTest.from_config_dict(config_dict)
 
     def grade(self, submission, path, parts):
-        cmdline = ["./", self.test_file, self.asm_file, "--json-output"]
+        cmdline = [
+            "./",
+            self.test_file,
+            self.asm_file,
+            "--json-output",
+            "--asm-print-level=3",
+        ]
         try:
             # Do not mix stderr into stdout because sometimes our friend
             # Roi printStackTrace()s or System.err.println()s, and that

--- a/zucchini/graders/lc3tools_legacy_grader.py
+++ b/zucchini/graders/lc3tools_legacy_grader.py
@@ -1,0 +1,101 @@
+import re
+from fractions import Fraction
+
+from ..grades import PartGrade
+from ..utils import PIPE, STDOUT, run_process
+from . import Part, ThreadedGrader
+
+
+class LC3ToolsLegacyTest(Part):
+    __slots__ = "name"
+
+    def __init__(self, name):
+        self.name = name
+
+    def description(self):
+        return self.name
+
+    @staticmethod
+    def format_cmd(cmd, **kwargs):
+        return [arg.format(**kwargs) for arg in cmd]
+
+    @staticmethod
+    def test_error_grade(message):
+        return PartGrade(Fraction(0), deductions=("error",), log=message)
+
+    def grade(self, path, grader):
+        grade = PartGrade(Fraction(1), log="")
+
+        run_cmd = self.format_cmd(grader.cmdline, testcase=self.name)
+
+        process = run_process(run_cmd, cwd=path, stdout=PIPE, stderr=STDOUT)
+
+        if process.returncode != 0:
+            return self.test_error_grade(
+                "tester exited with {} != 0:\n{}".format(
+                    process.returncode,
+                    (
+                        process.stdout.decode()
+                        if process.stdout is not None
+                        else "(no output)"
+                    ),
+                )
+            )
+
+        out_contents = process.stdout.decode()
+        out_contents = re.sub(r"\(\+.*pts\)", "", out_contents)
+        results = "".join(out_contents.strip().splitlines(keepends=True)[:-1])
+        grade.log += results
+
+        try:
+            summary = out_contents.splitlines()[-1]
+            score = summary.replace("/", " ").split()[3:5]
+            score[0] = Fraction(float(score[0]))
+            score[1] = Fraction(float(score[1]))
+            grade.score *= Fraction(score[0], score[1])
+        except (ValueError, IndexError):
+            return self.test_error_grade(
+                "Could not assemble file: \n{}".format(
+                    process.stdout.decode()
+                    if process.stdout is not None
+                    else "(no output)"
+                )
+            )
+        return grade
+
+
+class LC3ToolsLegacyGrader(ThreadedGrader):
+    """
+    Run a LC3Tools grader and collect the results.
+    """
+
+    DEFAULT_TIMEOUT = 30
+
+    def __init__(self, test_file, asm_file, timeout=None, num_threads=None):
+
+        super(LC3ToolsLegacyGrader, self).__init__(num_threads)
+        self.test_file = test_file
+        self.asm_file = asm_file
+
+        self.cmdline = [
+            "./" + self.test_file,
+            self.asm_file,
+            "--test-filter={testcase}",
+            "--tester-verbose",
+            "--asm-print-level=3",
+        ]
+
+        self.timeout = self.DEFAULT_TIMEOUT if timeout is None else timeout
+
+    def list_prerequisites(self):
+        return []
+
+    def part_from_config_dict(self, config_dict):
+        return LC3ToolsLegacyTest.from_config_dict(config_dict)
+
+    def grade_part(self, part, path, submission):
+        return part.grade(path, self)
+
+    def grade(self, submission, path, parts):
+
+        return super(LC3ToolsLegacyGrader, self).grade(submission, path, parts)

--- a/zucchini/graders/libcheck_grader.py
+++ b/zucchini/graders/libcheck_grader.py
@@ -101,7 +101,8 @@ class LibcheckTest(Part):
                 valgrind_process = run_process(valgrind_cmd,
                                                stdout=PIPE,
                                                stderr=STDOUT,
-                                               env=dict(os.environ, CK_FORK='no'),
+                                               env=dict(os.environ,
+                                                        CK_FORK='no'),
                                                cwd=path,
                                                timeout=grader.valgrind_timeout)
             except TimeoutExpired:


### PR DESCRIPTION
See https://github.com/gt-cs2110/lc3tools/pull/18.

With that PR, LC3Tools test executables can now output json like circuitsim-tester, which is a breeze to handle versus regex. This PR is based on those changes, while keeping the existing implementation (`LC3ToolsLegacyGrader`) in case we ever need to fall back to what we had before.